### PR TITLE
Add README to docs index if no other docs found

### DIFF
--- a/Changes
+++ b/Changes
@@ -8,6 +8,8 @@ Revision history for Perl extension PGXN::API
         Markdown files (but not MultiMarkdown files). This allows code fences
         to work and generates nicer HTML in general, but is stricter about
         certain things.
+      - The docs indexer now indexes a distribution's README if it is the only
+        documentation it finds in the distribution (#12).
 
 0.16.5  2016-06-22T18:03:05Z
       - Fixed a test failure on systems with a non-English locale, thanks to


### PR DESCRIPTION
If a distribution has a README and no other docs recognized by Text::Markup, add the README to the index. Previously the indexer only added the README to the distribution docs. It still does, but now also the docs index, because otherwise a docs search won't turn up results for a distribution with no other docs.

Add a test to be sure it actually indexes a README when there are no other docs.

Fixes #12.