### PR TITLE
Selectively index non-stable releases

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,15 +1,20 @@
 Revision history for Perl extension PGXN::API
 
 0.16.6
-      - Removed the `Capfile` and `eg` directory from the source (and distribution).
-        Examples for managing PGXN can now be found in the pgxn/pgxn-ops
-        repository on GitHub.
+      - Removed the `Capfile` and `eg` directory. Examples for managing PGXN
+        can now be found in the pgxn/pgxn-ops GitHub repository.
       - Switched from Text::Markdown to CommonMark for parsing and formatting
         Markdown files (but not MultiMarkdown files). This allows code fences
         to work and generates nicer HTML in general, but is stricter about
         certain things.
       - The docs indexer now indexes a distribution's README if it is the only
         documentation it finds in the distribution (#12).
+      - The docs indexer now strictly links an extension to the doc file
+        specified via the `docfile` key in its `provides` object, even if
+        it's a README (#10).
+      - The indexer will now index a testing release if there are no stable
+        releases, and will index an unstable release if there are neither stable
+        nor testing releases (#2).
 
 0.16.5  2016-06-22T18:03:05Z
       - Fixed a test failure on systems with a non-English locale, thanks to


### PR DESCRIPTION
PGXN::API has traditionally indexed only stable releases. This meant that a search returned no results for distributions that have no stable releases, even if the search query is relevant.

With this change, if a release's status is `testing` and there are no existing stable releases then add it to the index. If its status is `unstable` and there are no stable or testing releases then add it to the index.

This will make early releases easier to find via search queries.

Done by a bit of trickery with `local` and a field in the Indexer. `add_distribution` makes it `local`, and then `merge_distmeta` actually sets it once it has the relevant release history to make the assessment. That setting then sticks for the remaining methods `add_distribution` calls, but resets when it completes its work. This ensures it's set correctly for the specific release passed to each call to `add_distribution`.

Resolves #2.

While at it, update the `Changes` info about the removal of old deployment files and note the attention paid to `docfile` added in c13c746 (#32).