### PR TITLE
Fix handling of symlinks extracted from zip files

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for Perl extension PGXN::API
 
 0.20.2
+      - Fixed symlinks extracted from Zip files and permission errors when
+        re-indexing distributions.
 
 0.20.1  2024-02-15T22:18:14Z
       - Fixed a bug where a testing extension's version and abstract was not


### PR DESCRIPTION
Setting unix attributes was breaking the detection of symlinks by Archive::Zip, so it was just writing out a file with the name of the linked file in it.

Fix it by instead removing an existing file if it exists and not setting permissions for symlinks. This allows Arhive::Zip to always create a proper symlink. While at it, change the permissions for files to we writable by the owner, so as to avoid any other permissions issues when re-indexing an archive, which needs to replace existing files.

Finallky, don't abandon unzipping a file on error, but just move on to the next file.